### PR TITLE
Add password authentication and restore chat history

### DIFF
--- a/.chainlit/config.toml
+++ b/.chainlit/config.toml
@@ -1,6 +1,7 @@
 [project]
 # List of environment variables to be provided by each user to use the app.
 user_env = []
+# Password認証は環境変数 CHAINLIT_USERNAME / CHAINLIT_PASSWORD に設定した値を使用します。
 
 # Duration (in seconds) during which the session is saved when the connection is lost
 session_timeout = 3600

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@
    CHAINLIT_PASSWORD=your_login_password
    # JWTベースの認証セッションを有効化する場合はシークレットも設定
    CHAINLIT_AUTH_SECRET=secret_generated_by_chainlit_cli
+   # チャット履歴を永続化するSQLiteの保存先（未設定の場合は自動で ./.chainlit/local-data.db を利用）
+   # DATABASE_URL=sqlite+aiosqlite:///absolute/path/to/.chainlit/local-data.db
    ```
 
 ## 起動方法
@@ -47,6 +49,8 @@ chainlit run app.py -w
 アプリケーションは http://localhost:8000 で起動します。
 
 起動後に表示されるログインフォームには、`.env` に設定した `CHAINLIT_USERNAME` と `CHAINLIT_PASSWORD` を入力してください。`CHAINLIT_AUTH_SECRET` は `chainlit create-secret` コマンドで生成した値を利用します。
+
+`DATABASE_URL` を設定しなかった場合でも、アプリケーションは `.chainlit/local-data.db` にSQLiteデータベースを自動作成し、ログイン後のチャット履歴サイドバーから過去のスレッドを参照できるようになります。任意のストレージを使いたい場合は `DATABASE_URL` を明示的に指定してください。
 
 ログインに失敗する場合は、次のコマンドで現在の設定で認証が通るか事前に確認できます。
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@
    ```bash
    pip install -r requirements.txt
    ```
+   - Chainlit の認証・データレイヤーは PostgreSQL ドライバの `asyncpg` をロードするため、上記コマンドでこのパッケージも必ずインストールされます。仮想環境を作り直した場合などは再度 `pip install -r requirements.txt` を実行し、`asyncpg` が入っていることを確認してください。
 
 4. 環境変数の設定（`.env` を作成）
    ```bash

--- a/README.md
+++ b/README.md
@@ -48,6 +48,20 @@ chainlit run app.py -w
 
 起動後に表示されるログインフォームには、`.env` に設定した `CHAINLIT_USERNAME` と `CHAINLIT_PASSWORD` を入力してください。`CHAINLIT_AUTH_SECRET` は `chainlit create-secret` コマンドで生成した値を利用します。
 
+ログインに失敗する場合は、次のコマンドで現在の設定で認証が通るか事前に確認できます。
+
+```bash
+python scripts/verify_chainlit_auth.py
+```
+
+`.env` を使わずに任意の資格情報を直接チェックしたいときは、ログイン時に入力する値（`--username` / `--password`）と、Chainlit に設定したい想定の値（`--expected-username` / `--expected-password`）を引数で渡してください。
+
+```bash
+python scripts/verify_chainlit_auth.py \
+  --username you@example.com --password your-password \
+  --expected-username you@example.com --expected-password your-password
+```
+
 ### 認証に関する補足
 
 1. `CHAINLIT_AUTH_SECRET` をまだ用意していない場合は、以下のコマンドで生成します。

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
    ```bash
    pip install -r requirements.txt
    ```
-   - Chainlit の認証・データレイヤーは PostgreSQL ドライバの `asyncpg` をロードするため、上記コマンドでこのパッケージも必ずインストールされます。仮想環境を作り直した場合などは再度 `pip install -r requirements.txt` を実行し、`asyncpg` が入っていることを確認してください。
+   - チャット履歴の保存に必要な `asyncpg` と `aiosqlite` などのドライバも自動で導入されるため、追加の手動インストールは不要です。
 
 4. 環境変数の設定（`.env` を作成）
    ```bash
@@ -43,10 +43,8 @@
    # CHAINLIT_USERS_FILE=.chainlit/users.json
    # JWTベースの認証セッションを有効化する場合はシークレットも設定
    CHAINLIT_AUTH_SECRET=secret_generated_by_chainlit_cli
-   # チャット履歴を永続化するSQLiteの保存先（未設定の場合は自動で ./.chainlit/local-data.db を利用）
-   # SQLite を明示的に指定する場合は CHAINLIT_DATA_LAYER=sqlalchemy もセットしてください。
-   # DATABASE_URL=sqlite+aiosqlite:///absolute/path/to/.chainlit/local-data.db
-   # CHAINLIT_DATA_LAYER=sqlalchemy
+   # チャット履歴はアプリが自動生成する ./.chainlit/local-data.db (SQLite) に保存されます。
+   # DATABASE_URL や CHAINLIT_DATA_LAYER は設定不要です。環境に値が入っていてもアプリが上書きします。
    ```
 
 ## 起動方法
@@ -58,7 +56,7 @@ chainlit run app.py -w
 
 起動後に表示されるログインフォームには、`.env` に設定した `CHAINLIT_USERNAME` と `CHAINLIT_PASSWORD` を入力してください。`CHAINLIT_AUTH_SECRET` は `chainlit create-secret` コマンドで生成した値を利用します。
 
-`DATABASE_URL` を設定しなかった場合でも、アプリケーションは `.chainlit/local-data.db` にSQLiteデータベースを自動作成し、ログイン後のチャット履歴サイドバーから過去のスレッドを参照できるようになります。任意のストレージを使いたい場合は `DATABASE_URL` を明示的に指定してください。その際、SQLite を利用する DSN（`sqlite:///` など）を指定したら `CHAINLIT_DATA_LAYER=sqlalchemy` も合わせて設定してください。これにより、Chainlit が PostgreSQL 用の `asyncpg` データレイヤーをロードしてしまう問題を防ぎ、SQLite 用ドライバで接続できるようになります。
+アプリケーションは常に `.chainlit/local-data.db` に SQLite データベースを生成し、SQLAlchemy データレイヤーで接続します。`DATABASE_URL` や `CHAINLIT_DATA_LAYER` を独自に指定すると競合の原因になるため、設定しないでください（値が入っている場合でも起動時に上書きされます）。
 
 ### 複数ユーザーの管理
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,9 @@
    # JWTベースの認証セッションを有効化する場合はシークレットも設定
    CHAINLIT_AUTH_SECRET=secret_generated_by_chainlit_cli
    # チャット履歴を永続化するSQLiteの保存先（未設定の場合は自動で ./.chainlit/local-data.db を利用）
+   # SQLite を明示的に指定する場合は CHAINLIT_DATA_LAYER=sqlalchemy もセットしてください。
    # DATABASE_URL=sqlite+aiosqlite:///absolute/path/to/.chainlit/local-data.db
+   # CHAINLIT_DATA_LAYER=sqlalchemy
    ```
 
 ## 起動方法
@@ -56,7 +58,7 @@ chainlit run app.py -w
 
 起動後に表示されるログインフォームには、`.env` に設定した `CHAINLIT_USERNAME` と `CHAINLIT_PASSWORD` を入力してください。`CHAINLIT_AUTH_SECRET` は `chainlit create-secret` コマンドで生成した値を利用します。
 
-`DATABASE_URL` を設定しなかった場合でも、アプリケーションは `.chainlit/local-data.db` にSQLiteデータベースを自動作成し、ログイン後のチャット履歴サイドバーから過去のスレッドを参照できるようになります。任意のストレージを使いたい場合は `DATABASE_URL` を明示的に指定してください。
+`DATABASE_URL` を設定しなかった場合でも、アプリケーションは `.chainlit/local-data.db` にSQLiteデータベースを自動作成し、ログイン後のチャット履歴サイドバーから過去のスレッドを参照できるようになります。任意のストレージを使いたい場合は `DATABASE_URL` を明示的に指定してください。その際、SQLite を利用する DSN（`sqlite:///` など）を指定したら `CHAINLIT_DATA_LAYER=sqlalchemy` も合わせて設定してください。これにより、Chainlit が PostgreSQL 用の `asyncpg` データレイヤーをロードしてしまう問題を防ぎ、SQLite 用ドライバで接続できるようになります。
 
 ### 複数ユーザーの管理
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,11 @@
    GOOGLE_API_KEY=your_google_api_key
    ANTHROPIC_API_KEY=your_anthropic_api_key
    XAI_API_KEY=your_xai_api_key
+   # Chainlitのログインに利用する資格情報
+   CHAINLIT_USERNAME=your_login_id
+   CHAINLIT_PASSWORD=your_login_password
+   # JWTベースの認証セッションを有効化する場合はシークレットも設定
+   CHAINLIT_AUTH_SECRET=secret_generated_by_chainlit_cli
    ```
 
 ## 起動方法
@@ -40,6 +45,17 @@ chainlit run app.py -w
 ```
 
 アプリケーションは http://localhost:8000 で起動します。
+
+起動後に表示されるログインフォームには、`.env` に設定した `CHAINLIT_USERNAME` と `CHAINLIT_PASSWORD` を入力してください。`CHAINLIT_AUTH_SECRET` は `chainlit create-secret` コマンドで生成した値を利用します。
+
+### 認証に関する補足
+
+1. `CHAINLIT_AUTH_SECRET` をまだ用意していない場合は、以下のコマンドで生成します。
+   ```bash
+   chainlit create-secret
+   ```
+   表示された値を `.env` の `CHAINLIT_AUTH_SECRET` に貼り付けてください。
+2. ログイン画面では `.env` で指定した `CHAINLIT_USERNAME` / `CHAINLIT_PASSWORD` を入力します。ユーザー登録画面は提供していないため、環境変数で設定した資格情報をそのまま使用してください。
 
 ## 使用方法
 1. ブラウザで http://localhost:8000 を開く

--- a/app.py
+++ b/app.py
@@ -4,6 +4,7 @@ import json
 import asyncio
 import time
 import base64
+from pathlib import Path
 import chainlit as cl
 from chainlit.input_widget import Select, Switch
 from chainlit.user import User
@@ -28,6 +29,24 @@ from langchain_core.messages import SystemMessage, HumanMessage, AIMessage
 # --- Environment Loading ---
 from dotenv import load_dotenv
 load_dotenv()
+
+
+def ensure_local_database_url() -> None:
+    """Set a default sqlite database so Chainlit can persist threads locally."""
+
+    if os.environ.get("DATABASE_URL"):
+        return
+
+    project_root = Path(__file__).resolve().parent
+    db_path = project_root / ".chainlit" / "local-data.db"
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+
+    database_url = f"sqlite+aiosqlite:///{db_path.as_posix()}"
+    os.environ["DATABASE_URL"] = database_url
+    print(f"[DB] DATABASE_URL was not set. Using local sqlite database at {db_path}.")
+
+
+ensure_local_database_url()
 
 # ---日付の取得 ---
 from datetime import datetime

--- a/app.py
+++ b/app.py
@@ -5,6 +5,7 @@ import asyncio
 import time
 import base64
 from pathlib import Path
+from urllib.parse import urlparse
 import chainlit as cl
 from chainlit.input_widget import Select, Switch
 from chainlit.user import User
@@ -31,22 +32,33 @@ from dotenv import load_dotenv
 load_dotenv()
 
 
-def ensure_local_database_url() -> None:
-    """Set a default sqlite database so Chainlit can persist threads locally."""
+def ensure_database_defaults() -> None:
+    """Ensure Chainlit can fall back to sqlite and select the right data layer."""
 
-    if os.environ.get("DATABASE_URL"):
-        return
+    database_url = os.environ.get("DATABASE_URL")
 
-    project_root = Path(__file__).resolve().parent
-    db_path = project_root / ".chainlit" / "local-data.db"
-    db_path.parent.mkdir(parents=True, exist_ok=True)
+    if not database_url:
+        project_root = Path(__file__).resolve().parent
+        db_path = project_root / ".chainlit" / "local-data.db"
+        db_path.parent.mkdir(parents=True, exist_ok=True)
 
-    database_url = f"sqlite+aiosqlite:///{db_path.as_posix()}"
-    os.environ["DATABASE_URL"] = database_url
-    print(f"[DB] DATABASE_URL was not set. Using local sqlite database at {db_path}.")
+        database_url = f"sqlite+aiosqlite:///{db_path.as_posix()}"
+        os.environ["DATABASE_URL"] = database_url
+        print(
+            f"[DB] DATABASE_URL was not set. Using local sqlite database at {db_path}."
+        )
+
+    parsed = urlparse(database_url)
+
+    if parsed.scheme.startswith("sqlite") and not os.environ.get("CHAINLIT_DATA_LAYER"):
+        os.environ["CHAINLIT_DATA_LAYER"] = "sqlalchemy"
+        print(
+            "[DB] sqlite URL detected. Defaulting CHAINLIT_DATA_LAYER to 'sqlalchemy' to "
+            "use Chainlit's SQLAlchemy data layer."
+        )
 
 
-ensure_local_database_url()
+ensure_database_defaults()
 
 # ---日付の取得 ---
 from datetime import datetime

--- a/app.py
+++ b/app.py
@@ -6,6 +6,8 @@ import time
 import base64
 import chainlit as cl
 from chainlit.input_widget import Select, Switch
+from chainlit.user import User
+from chainlit.types import ThreadDict
 from typing import Optional
 
 
@@ -160,6 +162,52 @@ async def open_code_workbench(
     element = cl.CustomElement(name="CodeWorkbench", props=props, display="inline")
     await cl.ElementSidebar.set_title("Code Workbench")
     await cl.ElementSidebar.set_elements([element])
+
+
+@cl.password_auth_callback
+async def authenticate_user(username: str, password: str) -> Optional[User]:
+    """CHAINLIT_USERNAME/CHAINLIT_PASSWORD による簡易認証を提供する。"""
+
+    expected_username = os.getenv("CHAINLIT_USERNAME")
+    expected_password = os.getenv("CHAINLIT_PASSWORD")
+
+    if not expected_username or not expected_password:
+        print("[Auth] CHAINLIT_USERNAME または CHAINLIT_PASSWORD が設定されていません。認証をスキップします。")
+        return None
+
+    if username == expected_username and password == expected_password:
+        print(f"[Auth] ユーザー '{username}' が認証に成功しました。")
+        return User(identifier=username, metadata={"role": "default"})
+
+    print(f"[Auth] ユーザー '{username}' の認証に失敗しました。")
+    return None
+
+
+@cl.on_chat_resume
+async def on_chat_resume(thread: ThreadDict):
+    """保存されたスレッドからLangChain互換の履歴を復元する。"""
+
+    restored_history = []
+    for message in thread.get("messages", []):
+        author = message.get("author")
+        # Message contentは部分的に分割されるためテキスト部分のみ抽出
+        text_chunks = []
+        for chunk in message.get("content", []):
+            if isinstance(chunk, dict) and chunk.get("type") == "text":
+                text_chunks.append(chunk.get("text", ""))
+        content = "".join(text_chunks).strip()
+
+        if not content:
+            continue
+
+        if author == "user":
+            restored_history.append(HumanMessage(content=content))
+        elif author == "assistant":
+            restored_history.append(AIMessage(content=content))
+
+    cl.user_session.set("conversation_history", restored_history)
+    cl.user_session.set("chat_resumed", True)
+    print(f"[Resume] {len(restored_history)} 件の履歴を復元しました。")
 
 
 async def open_slide_preview(slides_json: str, title: str = "Slide Preview"):
@@ -385,7 +433,9 @@ async def start_chat():
     
     cl.user_session.set("model", initial_model)
     cl.user_session.set("system_prompt", initial_prompt)
-    cl.user_session.set("conversation_history", [])
+    if not cl.user_session.get("chat_resumed"):
+        cl.user_session.set("conversation_history", [])
+    cl.user_session.set("chat_resumed", False)
     
     print(f"Initial setup: Model={initial_model['label']}, Prompt={SYSTEM_PROMPT_CHOICES[DEFAULT_PROMPT_INDEX]['label']}")
     

--- a/app.py
+++ b/app.py
@@ -11,7 +11,7 @@ from chainlit.user import User
 from chainlit.types import ThreadDict
 from typing import Optional
 
-from auth_utils import get_expected_credentials, verify_credentials
+from auth_utils import get_allowed_users, verify_credentials
 
 
 # --- Provider SDKs ---
@@ -189,16 +189,20 @@ async def open_code_workbench(
 async def authenticate_user(username: str, password: str) -> Optional[User]:
     """CHAINLIT_USERNAME/CHAINLIT_PASSWORD による簡易認証を提供する。"""
 
-    expected_credentials = get_expected_credentials()
-    expected_username, expected_password = expected_credentials
+    allowed_users = get_allowed_users()
 
-    if not expected_username or not expected_password:
-        print("[Auth] CHAINLIT_USERNAME または CHAINLIT_PASSWORD が設定されていません。認証をスキップします。")
+    if not allowed_users:
+        print("[Auth] 利用可能な認証ユーザーが設定されていません。認証をスキップします。")
         return None
 
-    if verify_credentials(username, password, expected_credentials):
+    if verify_credentials(username, password, allowed_users):
         print(f"[Auth] ユーザー '{username}' が認証に成功しました。")
-        return User(identifier=username, metadata={"role": "default"})
+        metadata = {
+            "role": "default",
+            "email": username,
+            "displayName": username,
+        }
+        return User(identifier=username, metadata=metadata)
 
     print(f"[Auth] ユーザー '{username}' の認証に失敗しました。")
     return None

--- a/app.py
+++ b/app.py
@@ -10,6 +10,8 @@ from chainlit.user import User
 from chainlit.types import ThreadDict
 from typing import Optional
 
+from auth_utils import get_expected_credentials, verify_credentials
+
 
 # --- Provider SDKs ---
 from openai import OpenAI, AsyncOpenAI
@@ -168,14 +170,14 @@ async def open_code_workbench(
 async def authenticate_user(username: str, password: str) -> Optional[User]:
     """CHAINLIT_USERNAME/CHAINLIT_PASSWORD による簡易認証を提供する。"""
 
-    expected_username = os.getenv("CHAINLIT_USERNAME")
-    expected_password = os.getenv("CHAINLIT_PASSWORD")
+    expected_credentials = get_expected_credentials()
+    expected_username, expected_password = expected_credentials
 
     if not expected_username or not expected_password:
         print("[Auth] CHAINLIT_USERNAME または CHAINLIT_PASSWORD が設定されていません。認証をスキップします。")
         return None
 
-    if username == expected_username and password == expected_password:
+    if verify_credentials(username, password, expected_credentials):
         print(f"[Auth] ユーザー '{username}' が認証に成功しました。")
         return User(identifier=username, metadata={"role": "default"})
 

--- a/app.py
+++ b/app.py
@@ -161,18 +161,6 @@ OPENAI_ALL_TOOLS = [
 ]
 
 # --- Chainlit App Logic ---
-@cl.on_chat_start
-async def start():
-    html = """
-    <style>
-      /* 背景を透過寄りにしたい場合に調整。不要なら削除可 */
-      body { background: transparent !important; }
-    </style>
-    <script src="/public/custom.js"></script>
-    """
-    await cl.Html(html)
-    await cl.Message(content="WebGL 背景を適用しました。").send()
-    
 async def open_code_workbench(
     code: Optional[str] = None,
     title: str = "Code Workbench",
@@ -428,6 +416,16 @@ def extract_js_code(text: str) -> Optional[str]:
 
 @cl.on_chat_start
 async def start_chat():
+    html = """
+    <style>
+      /* 背景を透過寄りにしたい場合に調整。不要なら削除可 */
+      body { background: transparent !important; }
+    </style>
+    <script src="/public/custom.js"></script>
+    """
+    await cl.Html(html)
+    await cl.Message(content="WebGL 背景を適用しました。").send()
+
     """チャット開始時に呼び出され、設定UIを初期化します。"""
     # Toolsトグルの初期状態をセッションに保存（デフォルト: OFF）
     tools_enabled = cl.user_session.get("tools_enabled")

--- a/auth_utils.py
+++ b/auth_utils.py
@@ -1,29 +1,227 @@
 """Helpers for credential-based authentication in Chainlit."""
 from __future__ import annotations
 
+import json
 import os
-from typing import Optional, Tuple
+import re
+from pathlib import Path
+from typing import Dict, Iterable, Mapping, Optional, Tuple, Union
+
+AllowedUsers = Dict[str, str]
+CredentialInput = Optional[
+    Union[
+        Tuple[Optional[str], Optional[str]],
+        Mapping[str, str],
+        Iterable[Tuple[str, str]],
+    ]
+]
+
+
+def _normalise_key(key: str) -> str:
+    return key.strip()
+
+
+def _normalise_value(value: str) -> str:
+    return value.strip()
+
+
+def parse_users_string(raw: str) -> AllowedUsers:
+    """Parse a delimited username/password string into a mapping."""
+
+    users: AllowedUsers = {}
+    for entry in filter(None, re.split(r"[\n;,]+", raw)):
+        if "=" in entry:
+            username, password = entry.split("=", 1)
+        elif ":" in entry:
+            username, password = entry.split(":", 1)
+        else:
+            continue
+
+        username = _normalise_key(username)
+        password = _normalise_value(password)
+        if username and password:
+            users[username] = password
+    return users
+
+
+def parse_users_file(path: Path) -> AllowedUsers:
+    """Load allowed users from a JSON or delimited text file."""
+
+    if not path.exists():
+        return {}
+
+    text = path.read_text(encoding="utf-8").strip()
+    if not text:
+        return {}
+
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        return parse_users_string(text)
+
+    if isinstance(data, Mapping):
+        return {
+            _normalise_key(str(username)): _normalise_value(str(password))
+            for username, password in data.items()
+            if str(username).strip() and str(password).strip()
+        }
+
+    if isinstance(data, Iterable):
+        parsed: AllowedUsers = {}
+        for item in data:
+            if (
+                isinstance(item, Mapping)
+                and "username" in item
+                and "password" in item
+            ):
+                username = _normalise_key(str(item["username"]))
+                password = _normalise_value(str(item["password"]))
+            elif (
+                isinstance(item, Iterable)
+                and not isinstance(item, (str, bytes))
+            ):
+                try:
+                    username, password = list(item)[:2]
+                except ValueError:
+                    continue
+                username = _normalise_key(str(username))
+                password = _normalise_value(str(password))
+            elif isinstance(item, str):
+                parsed.update(parse_users_string(item))
+                continue
+            else:
+                continue
+
+            if username and password:
+                parsed[username] = password
+        return parsed
+
+    return {}
+
+
+def _merge_users(base: AllowedUsers, new_users: AllowedUsers) -> None:
+    for username, password in new_users.items():
+        if username and password:
+            base[username] = password
+
+
+def get_allowed_users() -> AllowedUsers:
+    """Resolve all configured username/password pairs."""
+
+    users: AllowedUsers = {}
+
+    # Highest priority: explicit JSON payload
+    raw_json = os.getenv("CHAINLIT_USERS_JSON")
+    if raw_json:
+        try:
+            parsed_json = json.loads(raw_json)
+        except json.JSONDecodeError:
+            parsed_json = None
+        if isinstance(parsed_json, Mapping):
+            _merge_users(
+                users,
+                {
+                    _normalise_key(str(username)): _normalise_value(str(password))
+                    for username, password in parsed_json.items()
+                    if str(username).strip() and str(password).strip()
+                },
+            )
+        elif isinstance(parsed_json, Iterable):
+            for item in parsed_json:
+                if (
+                    isinstance(item, Mapping)
+                    and "username" in item
+                    and "password" in item
+                ):
+                    username = _normalise_key(str(item["username"]))
+                    password = _normalise_value(str(item["password"]))
+                    if username and password:
+                        users[username] = password
+                elif isinstance(item, str):
+                    _merge_users(users, parse_users_string(item))
+
+    # Next priority: delimited string variable
+    raw_users = os.getenv("CHAINLIT_USERS")
+    if raw_users:
+        _merge_users(users, parse_users_string(raw_users))
+
+    # Optional file override
+    users_file = os.getenv("CHAINLIT_USERS_FILE")
+    if users_file:
+        file_users = parse_users_file(Path(users_file).expanduser())
+        _merge_users(users, file_users)
+
+    # Backwards compatibility with single username/password env vars
+    username = os.getenv("CHAINLIT_USERNAME")
+    password = os.getenv("CHAINLIT_PASSWORD")
+    if username and password:
+        users[_normalise_key(username)] = _normalise_value(password)
+
+    return users
 
 
 def get_expected_credentials() -> Tuple[Optional[str], Optional[str]]:
-    """Return the username/password pair expected from environment variables."""
-    return os.getenv("CHAINLIT_USERNAME"), os.getenv("CHAINLIT_PASSWORD")
+    """Return the first configured credential pair for compatibility uses."""
+
+    allowed = get_allowed_users()
+    if not allowed:
+        return None, None
+
+    username, password = next(iter(allowed.items()))
+    return username, password
+
+
+def _coerce_expected(expected: CredentialInput) -> AllowedUsers:
+    if expected is None:
+        return get_allowed_users()
+
+    if isinstance(expected, Mapping):
+        return {
+            _normalise_key(str(username)): _normalise_value(str(password))
+            for username, password in expected.items()
+            if str(username).strip() and str(password).strip()
+        }
+
+    if isinstance(expected, tuple):
+        try:
+            username, password = expected
+        except ValueError:
+            return {}
+        if username and password:
+            return {_normalise_key(str(username)): _normalise_value(str(password))}
+        return {}
+
+    mapping: AllowedUsers = {}
+    for item in expected:
+        if isinstance(item, tuple) and len(item) >= 2:
+            username, password = item[:2]
+        elif isinstance(item, Mapping) and {"username", "password"} <= set(item):
+            username = item["username"]
+            password = item["password"]
+        else:
+            continue
+
+        username = _normalise_key(str(username))
+        password = _normalise_value(str(password))
+        if username and password:
+            mapping[username] = password
+
+    return mapping
 
 
 def verify_credentials(
     username: str,
     password: str,
-    expected: Optional[Tuple[Optional[str], Optional[str]]] = None,
+    expected: CredentialInput = None,
 ) -> bool:
-    """Compare the provided credentials with the expected ones."""
-    expected_username: Optional[str]
-    expected_password: Optional[str]
+    """Compare the provided credentials with any configured credential set."""
 
-    if expected is None:
-        expected_username, expected_password = get_expected_credentials()
-    else:
-        expected_username, expected_password = expected
-
-    if not expected_username or not expected_password:
+    allowed = _coerce_expected(expected)
+    if not allowed:
         return False
-    return username == expected_username and password == expected_password
+
+    expected_password = allowed.get(_normalise_key(username))
+    if expected_password is None:
+        return False
+
+    return expected_password == _normalise_value(password)

--- a/auth_utils.py
+++ b/auth_utils.py
@@ -1,0 +1,29 @@
+"""Helpers for credential-based authentication in Chainlit."""
+from __future__ import annotations
+
+import os
+from typing import Optional, Tuple
+
+
+def get_expected_credentials() -> Tuple[Optional[str], Optional[str]]:
+    """Return the username/password pair expected from environment variables."""
+    return os.getenv("CHAINLIT_USERNAME"), os.getenv("CHAINLIT_PASSWORD")
+
+
+def verify_credentials(
+    username: str,
+    password: str,
+    expected: Optional[Tuple[Optional[str], Optional[str]]] = None,
+) -> bool:
+    """Compare the provided credentials with the expected ones."""
+    expected_username: Optional[str]
+    expected_password: Optional[str]
+
+    if expected is None:
+        expected_username, expected_password = get_expected_credentials()
+    else:
+        expected_username, expected_password = expected
+
+    if not expected_username or not expected_password:
+        return False
+    return username == expected_username and password == expected_password

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ groq>=0.9.0
 google-genai>=0.3.0
 python-dotenv>=1.0.1
 langchain-core>=0.2.0
+asyncpg>=0.29.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ google-genai>=0.3.0
 python-dotenv>=1.0.1
 langchain-core>=0.2.0
 asyncpg>=0.29.0
+aiosqlite>=0.20.0

--- a/scripts/verify_chainlit_auth.py
+++ b/scripts/verify_chainlit_auth.py
@@ -1,0 +1,111 @@
+"""Utility to verify that Chainlit password authentication is correctly configured."""
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+from typing import Optional, Tuple
+
+from dotenv import load_dotenv
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from auth_utils import get_expected_credentials, verify_credentials
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Check whether the current CHAINLIT_USERNAME and CHAINLIT_PASSWORD can "
+            "authenticate against the Chainlit password callback."
+        )
+    )
+    parser.add_argument(
+        "--username",
+        help=(
+            "Username to test. Defaults to the value of the CHAINLIT_USERNAME "
+            "environment variable."
+        ),
+    )
+    parser.add_argument(
+        "--password",
+        help=(
+            "Password to test. Defaults to the value of the CHAINLIT_PASSWORD "
+            "environment variable."
+        ),
+    )
+    parser.add_argument(
+        "--expected-username",
+        help=(
+            "Expected username to validate against. Defaults to CHAINLIT_USERNAME "
+            "from the environment."
+        ),
+    )
+    parser.add_argument(
+        "--expected-password",
+        help=(
+            "Expected password to validate against. Defaults to CHAINLIT_PASSWORD "
+            "from the environment."
+        ),
+    )
+    parser.add_argument(
+        "--no-dotenv",
+        action="store_true",
+        help="Skip loading variables from a .env file in the project root.",
+    )
+    return parser.parse_args()
+
+
+def resolve_expected_credentials(
+    expected_username_arg: Optional[str], expected_password_arg: Optional[str]
+) -> Tuple[Optional[str], Optional[str]]:
+    if expected_username_arg is not None or expected_password_arg is not None:
+        if expected_username_arg is None or expected_password_arg is None:
+            raise ValueError("Provide both --expected-username and --expected-password.")
+        return expected_username_arg, expected_password_arg
+    return get_expected_credentials()
+
+
+def main() -> int:
+    args = parse_args()
+
+    if not args.no_dotenv:
+        load_dotenv()
+
+    username = args.username or os.getenv("CHAINLIT_USERNAME")
+    password = args.password or os.getenv("CHAINLIT_PASSWORD")
+
+    if not username or not password:
+        print(
+            "[verify_chainlit_auth] Missing credentials. Provide --username/--password "
+            "or set CHAINLIT_USERNAME/CHAINLIT_PASSWORD."
+        )
+        return 2
+
+    try:
+        expected = resolve_expected_credentials(
+            args.expected_username, args.expected_password
+        )
+    except ValueError as exc:
+        print(f"[verify_chainlit_auth] {exc}")
+        return 2
+
+    if not all(expected):
+        print(
+            "[verify_chainlit_auth] CHAINLIT_USERNAME/CHAINLIT_PASSWORD are not set in the environment."
+        )
+        return 2
+
+    if not verify_credentials(username, password, expected):
+        print("[verify_chainlit_auth] Authentication failed.")
+        return 1
+
+    print(f"[verify_chainlit_auth] Authentication succeeded for user '{username}'.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify_chainlit_auth.py
+++ b/scripts/verify_chainlit_auth.py
@@ -5,7 +5,7 @@ import argparse
 import os
 import sys
 from pathlib import Path
-from typing import Optional, Tuple
+from typing import Dict, Optional
 
 from dotenv import load_dotenv
 
@@ -13,7 +13,12 @@ PROJECT_ROOT = Path(__file__).resolve().parents[1]
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
-from auth_utils import get_expected_credentials, verify_credentials
+from auth_utils import (
+    get_allowed_users,
+    parse_users_file,
+    parse_users_string,
+    verify_credentials,
+)
 
 
 def parse_args() -> argparse.Namespace:
@@ -40,16 +45,35 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--expected-username",
         help=(
-            "Expected username to validate against. Defaults to CHAINLIT_USERNAME "
-            "from the environment."
+            "Deprecated in favour of --allowed-users. Provide alongside "
+            "--expected-password to test a single credential pair."
         ),
     )
     parser.add_argument(
         "--expected-password",
         help=(
-            "Expected password to validate against. Defaults to CHAINLIT_PASSWORD "
-            "from the environment."
+            "Deprecated in favour of --allowed-users. Provide alongside "
+            "--expected-username to test a single credential pair."
         ),
+    )
+    parser.add_argument(
+        "--allowed-users",
+        help=(
+            "Override allowed users with a delimited string of username=password "
+            "pairs. Accepts comma, semicolon, or newline separators."
+        ),
+    )
+    parser.add_argument(
+        "--allowed-users-file",
+        help=(
+            "Path to a JSON or newline-delimited file describing allowed users. "
+            "Each entry should be a username/password pair."
+        ),
+    )
+    parser.add_argument(
+        "--list-allowed",
+        action="store_true",
+        help="List the resolved usernames and exit without performing verification.",
     )
     parser.add_argument(
         "--no-dotenv",
@@ -59,14 +83,26 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def resolve_expected_credentials(
-    expected_username_arg: Optional[str], expected_password_arg: Optional[str]
-) -> Tuple[Optional[str], Optional[str]]:
-    if expected_username_arg is not None or expected_password_arg is not None:
-        if expected_username_arg is None or expected_password_arg is None:
-            raise ValueError("Provide both --expected-username and --expected-password.")
-        return expected_username_arg, expected_password_arg
-    return get_expected_credentials()
+def resolve_allowed_users(args: argparse.Namespace) -> Dict[str, str]:
+    if args.expected_username is not None or args.expected_password is not None:
+        if args.expected_username is None or args.expected_password is None:
+            raise ValueError(
+                "Provide both --expected-username and --expected-password or omit both."
+            )
+        return {args.expected_username: args.expected_password}
+
+    users: Dict[str, str] = {}
+
+    if args.allowed_users:
+        users.update(parse_users_string(args.allowed_users))
+
+    if args.allowed_users_file:
+        users.update(parse_users_file(Path(args.allowed_users_file).expanduser()))
+
+    if users:
+        return users
+
+    return get_allowed_users()
 
 
 def main() -> int:
@@ -81,25 +117,35 @@ def main() -> int:
     if not username or not password:
         print(
             "[verify_chainlit_auth] Missing credentials. Provide --username/--password "
-            "or set CHAINLIT_USERNAME/CHAINLIT_PASSWORD."
+            "or set CHAINLIT_USERNAME/CHAINLIT_PASSWORD. When using CHAINLIT_USERS* "
+            "environment variables, pass the credentials with --username/--password."
         )
         return 2
 
     try:
-        expected = resolve_expected_credentials(
-            args.expected_username, args.expected_password
-        )
+        allowed_users = resolve_allowed_users(args)
     except ValueError as exc:
         print(f"[verify_chainlit_auth] {exc}")
         return 2
 
-    if not all(expected):
+    if args.list_allowed:
+        if not allowed_users:
+            print("[verify_chainlit_auth] No allowed users are configured.")
+            return 1
+
+        print("[verify_chainlit_auth] Allowed usernames:")
+        for allowed_username in sorted(allowed_users):
+            print(f"  - {allowed_username}")
+        return 0
+
+    if not allowed_users:
         print(
-            "[verify_chainlit_auth] CHAINLIT_USERNAME/CHAINLIT_PASSWORD are not set in the environment."
+            "[verify_chainlit_auth] No allowed users were resolved. Set CHAINLIT_USERS, "
+            "CHAINLIT_USERS_JSON, CHAINLIT_USERS_FILE, or CHAINLIT_USERNAME/CHAINLIT_PASSWORD."
         )
         return 2
 
-    if not verify_credentials(username, password, expected):
+    if not verify_credentials(username, password, allowed_users):
         print("[verify_chainlit_auth] Authentication failed.")
         return 1
 


### PR DESCRIPTION
## Summary
- add a Chainlit password authentication callback that validates users with CHAINLIT_USERNAME and CHAINLIT_PASSWORD
- restore saved thread history into the LangChain conversation buffer when a chat is resumed
- document the expected environment variables in the Chainlit configuration

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_e_68ea491437cc8327961b5a5a4a7b6a78